### PR TITLE
Fixed order of group deployment command "Ready-to-go" Azure VM

### DIFF
--- a/docs/Azure.md
+++ b/docs/Azure.md
@@ -20,7 +20,7 @@ Example: ```az group create -l westus2 -n Folding-COVID19```
 
 * Now that you have a new RG created, you can go ahead and deploy the VM in a single command: <br>
 
-```az deployment group create --name "folding" --resource-group "Folding-COVID19" --template-uri https://raw.githubusercontent.com/likamrat/foldingathome/master/deploy/azure/azuredeploy.json```
+```az group deployment create --name "folding" --resource-group "Folding-COVID19" --template-uri https://raw.githubusercontent.com/likamrat/foldingathome/master/deploy/azure/azuredeploy.json```
 
 **Note: Don't forget to match the resource group name based on the one you created**
 


### PR DESCRIPTION
This is a non-issue
```
az deployment: 'group' is not in the 'az deployment' command group. See 'az deployment --help'. If the command is from an extension, please make sure the corresponding extension is installed. To learn more about extensions, please visit https://docs.microsoft.com/en-us/cli/azure/azure-cli-extensions-overview
```

> EDIT
> `az deployment group` was added in azure-cli 2.2.0. 
> ensure you If you upgrade to latest az cli and the command will work as expected